### PR TITLE
Fixes CGContext Errors on Simulator

### DIFF
--- a/ImageEditor/HFImageEditorViewController.m
+++ b/ImageEditor/HFImageEditorViewController.m
@@ -554,10 +554,10 @@ static const NSTimeInterval kAnimationIntervalTransform = 0.2;
     CGContextRef context = CGBitmapContextCreate(NULL,
                                                  size.width,
                                                  size.height,
-                                                 8, //CGImageGetBitsPerComponent(source),
+                                                 CGImageGetBitsPerComponent(source), //8,
                                                  0,
                                                  CGImageGetColorSpace(source),
-                                                 kCGImageAlphaNoneSkipFirst//CGImageGetBitmapInfo(source)
+                                                 CGImageGetBitmapInfo(source) //kCGImageAlphaNoneSkipFirst
                                                  );
     
     CGContextSetInterpolationQuality(context, quality);


### PR DESCRIPTION
When testing this on the iOS 6.1 simulator, I encountered CGContext errors and this fork fixed it. More info here: http://stackoverflow.com/questions/17985167/cgcontext-errors-only-in-simulator/17985431?noredirect=1#comment26295758_17985431
