### PR TITLE
Handling offset frameRects properly

### DIFF
--- a/ImageEditor/HFImageEditorFrameView.m
+++ b/ImageEditor/HFImageEditorFrameView.m
@@ -52,15 +52,15 @@
 - (void)setCropRect:(CGRect)cropRect
 {
     if(!CGRectEqualToRect(_cropRect,cropRect)){
-        _cropRect = cropRect;
+        _cropRect = CGRectOffset(cropRect, self.frame.origin.x, self.frame.origin.y);
         UIGraphicsBeginImageContextWithOptions(self.bounds.size, NO, 0.f);
         CGContextRef context = UIGraphicsGetCurrentContext();
         [[UIColor blackColor] setFill];
         UIRectFill(self.bounds);
         CGContextSetStrokeColorWithColor(context, [[UIColor whiteColor] colorWithAlphaComponent:0.5].CGColor);
-        CGContextStrokeRect(context, _cropRect);
+        CGContextStrokeRect(context, cropRect);
         [[UIColor clearColor] setFill];
-        UIRectFill(CGRectInset(_cropRect, 1, 1));
+        UIRectFill(CGRectInset(cropRect, 1, 1));
         self.imageView.image = UIGraphicsGetImageFromCurrentImageContext();
 
         UIGraphicsEndImageContext();


### PR DESCRIPTION
This fixes an issue I was having where I have a navigation bar above the frameView, which caused the image to be offset from the crop area incorrectly. This is because cropRect is used in view-space in HFImageEditorFrameView, but in screen-space in HFImageEditorViewController.

Commit message:
Making HFImageEditorFrameView store screenspace coordinates for cropRect so that HFImageEditorViewController respects frameView origins other than 0,0

P.S. This library really helped me out. Thanks!
