### PR TITLE
Fill padding color of cropped image with background color of view

### DIFF
--- a/ImageEditor/HFImageEditorViewController.h
+++ b/ImageEditor/HFImageEditorViewController.h
@@ -19,6 +19,7 @@ typedef void(^HFImageEditorDoneCallback)(UIImage *image, BOOL canceled);
 @property(nonatomic,assign) CGFloat outputWidth;
 @property(nonatomic,assign) CGFloat minimumScale;
 @property(nonatomic,assign) CGFloat maximumScale;
+@property(nonatomic,assign) CGColorRef outputBackgroundColor;
 
 @property(nonatomic,assign) BOOL panEnabled;
 @property(nonatomic,assign) BOOL rotateEnabled;

--- a/ImageEditor/HFImageEditorViewController.m
+++ b/ImageEditor/HFImageEditorViewController.m
@@ -610,7 +610,7 @@ static const NSTimeInterval kAnimationIntervalTransform = 0.2;
                                                  0,
                                                  CGImageGetColorSpace(source),
                                                  CGImageGetBitmapInfo(source));
-    CGContextSetFillColorWithColor(context,  [[UIColor clearColor] CGColor]);
+    CGContextSetFillColorWithColor(context,  [self.view.backgroundColor CGColor]);
     CGContextFillRect(context, CGRectMake(0, 0, outputSize.width, outputSize.height));
     
     CGAffineTransform uiCoords = CGAffineTransformMakeScale(outputSize.width/cropRect.size.width,

--- a/ImageEditor/HFImageEditorViewController.m
+++ b/ImageEditor/HFImageEditorViewController.m
@@ -79,6 +79,7 @@ static const NSTimeInterval kAnimationIntervalTransform = 0.2;
     self.panEnabled = YES;
     self.scaleEnabled = YES;
     self.rotateEnabled = YES;
+    self.outputBackgroundColor = [[UIColor clearColor] CGColor];
 }
 
 ////////////////////////////////////////////////////////////////////////////////////////////////////
@@ -610,7 +611,7 @@ static const NSTimeInterval kAnimationIntervalTransform = 0.2;
                                                  0,
                                                  CGImageGetColorSpace(source),
                                                  CGImageGetBitmapInfo(source));
-    CGContextSetFillColorWithColor(context,  [self.view.backgroundColor CGColor]);
+    CGContextSetFillColorWithColor(context, self.outputBackgroundColor);
     CGContextFillRect(context, CGRectMake(0, 0, outputSize.width, outputSize.height));
     
     CGAffineTransform uiCoords = CGAffineTransformMakeScale(outputSize.width/cropRect.size.width,

--- a/README.md
+++ b/README.md
@@ -68,7 +68,7 @@ The width of the cropped image. If not defined, the width of the source image is
 The bounds for image scaling. If not defined, image zoom is unlimited.
 
 #### checkBounds
-Set to true to bound the image transform so that you dont' get a black backround on the resulting image.
+Set to true to bound the image transform so that you dont' get a color of backround view on the resulting image.
 
 #### panEnabled, rotateEnabled, scaleEnabled, tapToResetEnabled
 BOOL property to enable/disable specific gestures

--- a/README.md
+++ b/README.md
@@ -68,7 +68,10 @@ The width of the cropped image. If not defined, the width of the source image is
 The bounds for image scaling. If not defined, image zoom is unlimited.
 
 #### checkBounds
-Set to true to bound the image transform so that you dont' get a color of backround view on the resulting image.
+Set to true to bound the image transform so that you dont' get a backround on the resulting image.
+
+#### outputBackgroundColor
+The color used to fill a background of the resulting image if checkBounds property is set to false and a margin exists.
 
 #### panEnabled, rotateEnabled, scaleEnabled, tapToResetEnabled
 BOOL property to enable/disable specific gestures


### PR DESCRIPTION
Currently, if users scale an image smaller than bounds area, a padding area is filled with black color. This PR change the behaviour to filling padding with a color of the background view. The result should be more WYSIWYG for users.
